### PR TITLE
Add throttling functionality to feedback endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/swagger": "^8.1.1",
+        "@nestjs/throttler": "^6.4.0",
         "@nestjs/typeorm": "^11.0.0",
         "bcryptjs": "^3.0.2",
         "class-transformer": "^0.5.1",
@@ -1850,6 +1851,16 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.4.0.tgz",
+      "integrity": "sha512-osL67i0PUuwU5nqSuJjtUJZMkxAnYB4VldgYUMGzvYRJDCqGRFMWbsbzm/CkUtPLRL30I8T74Xgt/OQxnYokiA==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/typeorm": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^8.1.1",
+    "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",
     "bcryptjs": "^3.0.2",
     "class-transformer": "^0.5.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -9,12 +11,30 @@ import { Book } from './books/entities/book.entity';
 import { Feedback } from './feedback/entities/feedback.entity';
 import { BooksModule } from './books/books.module';
 import { FeedbackModule } from './feedback/feedback.module';
+import { CustomThrottlerGuard } from './common/guards/custom-throttler.guard';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    ThrottlerModule.forRoot([
+      {
+        name: 'short',
+        ttl: 1000, // 1 second
+        limit: 10, // 10 requests per second
+      },
+      {
+        name: 'medium',
+        ttl: 10000, // 10 seconds
+        limit: 20, // 20 requests per 10 seconds
+      },
+      {
+        name: 'long',
+        ttl: 60000, // 1 minute
+        limit: 100, // 100 requests per minute
+      },
+    ]),
     TypeOrmModule.forRoot({
       type: 'postgres',
       host: process.env.DB_HOST || 'localhost',
@@ -30,6 +50,12 @@ import { FeedbackModule } from './feedback/feedback.module';
     FeedbackModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_GUARD,
+      useClass: CustomThrottlerGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/common/guards/custom-throttler.guard.ts
+++ b/src/common/guards/custom-throttler.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+@Injectable()
+export class CustomThrottlerGuard extends ThrottlerGuard {
+  protected async getTracker(req: Record<string, any>): Promise<string> {
+    // For authenticated users, use user ID for tracking
+    const userId = req.user?.id;
+    if (userId) {
+      return `user-${userId}`;
+    }
+    // For unauthenticated users, use IP address
+    return req.ip;
+  }
+}

--- a/src/feedback/dto/feedback.dto.ts
+++ b/src/feedback/dto/feedback.dto.ts
@@ -29,6 +29,23 @@ export class ModerateFeedbackDto {
   status: FeedbackStatus;
 }
 
+export class UpdateFeedbackDto {
+  @ApiPropertyOptional({ example: 5, description: 'Updated rating from 1 to 5 stars', minimum: 1, maximum: 5 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating?: number;
+
+  @ApiPropertyOptional({ example: 'Updated comment: This book is amazing!', description: 'Updated feedback comment', minLength: 1, maxLength: 1000 })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  @MaxLength(1000)
+  comment?: string;
+}
+
 export class ListFeedbackQueryDto {
   @ApiPropertyOptional({ example: 1, description: 'Page number', minimum: 1, default: 1 })
   @IsOptional()

--- a/src/feedback/feedback-throttler.guard.ts
+++ b/src/feedback/feedback-throttler.guard.ts
@@ -1,0 +1,79 @@
+import { Injectable, ExecutionContext, HttpException, HttpStatus } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+@Injectable()
+export class FeedbackThrottlerGuard extends ThrottlerGuard {
+  private readonly requestTimes = new Map<string, number>();
+  private readonly RATE_LIMIT_TTL = 60000; // 1 minute in milliseconds
+  private readonly RATE_LIMIT_COUNT = 1; // 1 request per minute
+
+  protected async getTracker(req: Record<string, any>): Promise<string> {
+    // This guard runs after JWT authentication, so req.user should be available
+    const userId = req.user?.id;
+    if (userId) {
+      const tracker = `feedback-user-${userId}`;
+      console.log(`Feedback rate limiting tracker for user ${userId}: ${tracker}`);
+      return tracker;
+    }
+    // Fallback to IP if no user (shouldn't happen with JWT guard)
+    const ipTracker = req.ip;
+    console.log(`Feedback rate limiting tracker for IP (fallback): ${ipTracker}`);
+    return ipTracker;
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Only apply throttling to POST requests (feedback creation)
+    const request = context.switchToHttp().getRequest();
+    if (request.method !== 'POST') {
+      return true; // Allow all non-POST requests
+    }
+
+    const tracker = await this.getTracker(request);
+    const currentTime = Date.now();
+    
+    // Clean up old entries first
+    this.cleanupOldEntries();
+    
+    // Check if user has made a request recently
+    const lastRequestTime = this.requestTimes.get(tracker);
+    
+    if (lastRequestTime) {
+      const timeDifference = currentTime - lastRequestTime;
+      const timeDifferenceSeconds = Math.round(timeDifference / 1000);
+      
+      console.log(`Checking rate limit for ${tracker}. Last request: ${new Date(lastRequestTime)}, Current: ${new Date(currentTime)}, Difference: ${timeDifferenceSeconds} seconds`);
+      
+      if (timeDifference < this.RATE_LIMIT_TTL) {
+        const remainingSeconds = Math.ceil((this.RATE_LIMIT_TTL - timeDifference) / 1000);
+        console.log(`Rate limit exceeded for ${tracker}. Please wait ${remainingSeconds} more seconds.`);
+        throw new HttpException(
+          {
+            statusCode: HttpStatus.TOO_MANY_REQUESTS,
+            message: `Too Many Requests - Rate limit exceeded (1 feedback per minute per user). Please wait ${remainingSeconds} more seconds.`,
+            error: 'Too Many Requests',
+            retryAfter: remainingSeconds
+          },
+          HttpStatus.TOO_MANY_REQUESTS
+        );
+      }
+    }
+    
+    // Record this request
+    this.requestTimes.set(tracker, currentTime);
+    console.log(`Request allowed for ${tracker} at ${new Date(currentTime)}`);
+    
+    return true;
+  }
+
+  private cleanupOldEntries(): void {
+    const currentTime = Date.now();
+    const oneMinuteAgo = currentTime - this.RATE_LIMIT_TTL;
+    
+    for (const [key, timestamp] of this.requestTimes.entries()) {
+      if (timestamp < oneMinuteAgo) {
+        this.requestTimes.delete(key);
+        console.log(`Cleaned up old entry for ${key}`);
+      }
+    }
+  }
+}

--- a/src/feedback/feedback.module.ts
+++ b/src/feedback/feedback.module.ts
@@ -6,11 +6,12 @@ import { Feedback } from './entities/feedback.entity';
 import { User } from '../auth/entities/user.entity';
 import { Book } from '../books/entities/book.entity';
 import { RolesGuard } from '../auth/guards/roles.guard';
+import { FeedbackThrottlerGuard } from './feedback-throttler.guard';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Feedback, User, Book])],
   controllers: [FeedbackController],
-  providers: [FeedbackService, RolesGuard],
+  providers: [FeedbackService, RolesGuard, FeedbackThrottlerGuard],
   exports: [FeedbackService],
 })
 export class FeedbackModule {}


### PR DESCRIPTION
- Introduced @nestjs/throttler for rate limiting on feedback creation, allowing 1 feedback per user per minute.
- Implemented CustomThrottlerGuard to track requests based on user ID or IP address.
- Updated FeedbackController to utilize FeedbackThrottlerGuard for the create feedback endpoint.
- Added update feedback functionality with appropriate DTO and validation.
- Enhanced FeedbackService to support updating feedback while enforcing ownership checks.